### PR TITLE
feat(pagination): more dark

### DIFF
--- a/theme.user.css
+++ b/theme.user.css
@@ -478,4 +478,30 @@
   .hover-bg-build-failed-dark:hover {
     background-color: rgb(var(--color-alert-error) / 70%);
   }
+  
+  /** Pagination */
+  .pagination li a,
+  .pagination li.disabled a,
+  .pagination li a:hover,
+  .pagination li.disabled a:hover {
+      border-color: var(--color-border-primary);
+  }
+    
+  .pagination li a {
+      background-color: var(--color-bg-primary);   
+  }
+    
+  .pagination li.disabled a {
+      background-color: var(--color-bg-secondary);
+  }
+
+  .pagination li a:hover,
+  .pagination li.disabled a:hover,
+  .pagination li a:focus {
+      background-color: var(--color-bg-tertiary);
+  }
+
+  .pagination li a:focus {
+      border-color: var(--color-state-focus-border);
+  }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/683086/112091972-84723600-8b64-11eb-8686-e694b9fcd823.png)

One take on https://github.com/one-dark/buildkite-dark-theme/issues/2... Not sure if it's actually "on brand" to keep any of the Buildkite primary color.